### PR TITLE
Format 4xx/5xx status codes and return error code 

### DIFF
--- a/src/binarylane/console/printers/formatter.py
+++ b/src/binarylane/console/printers/formatter.py
@@ -98,7 +98,10 @@ def _extract_primary(response: Any) -> Any:
 
     If the response is a 'wrapper' type containing one model type (e.g. a list or single entity), we want to
     extract that while ignore the descriptor properties like meta, links, additional_properties.
+    ProblemDetails and ValidationProblemDetails are returned as is.
     """
+    if isinstance(response, (ProblemDetails, ValidationProblemDetails)):
+        return response
 
     response_type = type(response)
     type_hints = _get_primary_candidates(response_type)

--- a/src/binarylane/console/printers/json_printer.py
+++ b/src/binarylane/console/printers/json_printer.py
@@ -9,5 +9,5 @@ from binarylane.console.printers.printer import Printer
 class JsonPrinter(Printer):
     """Output an API response as 'raw' JSON"""
 
-    def print(self, response: Any, fields: Optional[List[str]] = None) -> None:
-        print(json.dumps(response.to_dict()))
+    def _format(self, response: Any, _header: bool, _fields: Optional[List[str]] = None) -> str:
+        return json.dumps(response.to_dict(), indent=2)

--- a/src/binarylane/console/printers/plain_printer.py
+++ b/src/binarylane/console/printers/plain_printer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import List, Union
 
 from terminaltables import SingleTable  # type: ignore
 
@@ -10,9 +10,10 @@ from binarylane.console.printers.printer import _TablePrinter
 class PlainPrinter(_TablePrinter):
     """Output a plain (borderless) table"""
 
-    def _print(self, data: Any) -> None:
+    def _render(self, data: List[List[str]], title: Union[str, None]) -> str:
         table = SingleTable(data)
         table.inner_heading_row_border = False
         table.outer_border = False
         table.inner_column_border = False
-        print(table.table)
+        table.title = title
+        return table.table

--- a/src/binarylane/console/printers/plain_printer.py
+++ b/src/binarylane/console/printers/plain_printer.py
@@ -15,5 +15,5 @@ class PlainPrinter(_TablePrinter):
         table.inner_heading_row_border = False
         table.outer_border = False
         table.inner_column_border = False
-        table.title = title
-        return table.table
+        title = title + "\n" if title else ""
+        return title + table.table

--- a/src/binarylane/console/printers/printer.py
+++ b/src/binarylane/console/printers/printer.py
@@ -44,7 +44,7 @@ class _TablePrinter(Printer):
         """format the response data"""
         formatted = formatter.format_response(response, header, fields)
 
-        if isinstance(formatted["table"], list):
+        if isinstance(formatted["table"], list) and len(formatted["table"]) > 0:
             return self._render(formatted["table"], formatted["title"]) + "\n"
 
         if isinstance(formatted["title"], str):

--- a/src/binarylane/console/printers/table_printer.py
+++ b/src/binarylane/console/printers/table_printer.py
@@ -18,5 +18,5 @@ class TablePrinter(_TablePrinter):
     def _render(self, data: List[List[str]], title: Union[str, None]) -> str:
         table = self.table_class(data)
         table.inner_heading_row_border = self.header
-        table.title = title
-        return table.table
+        title = title + "\n" if title else ""
+        return title + table.table

--- a/src/binarylane/console/printers/table_printer.py
+++ b/src/binarylane/console/printers/table_printer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Any
+from typing import List, Union
 
 from terminaltables import DoubleTable, SingleTable  # type: ignore
 
@@ -15,7 +15,8 @@ class TablePrinter(_TablePrinter):
         super().__init__()
         self.table_class = SingleTable if sys.stdout.isatty() else DoubleTable
 
-    def _print(self, data: Any) -> None:
+    def _render(self, data: List[List[str]], title: Union[str, None]) -> str:
         table = self.table_class(data)
         table.inner_heading_row_border = self.header
-        print(table.table)
+        table.title = title
+        return table.table

--- a/src/binarylane/console/printers/tsv_printer.py
+++ b/src/binarylane/console/printers/tsv_printer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import List, Union
 
 from binarylane.console.printers.printer import _TablePrinter
 
@@ -8,6 +8,6 @@ from binarylane.console.printers.printer import _TablePrinter
 class TsvPrinter(_TablePrinter):
     """Output a formatted response as tab-separated values"""
 
-    def _print(self, data: Any) -> None:
-        for item in data:
-            print("\t".join(item).replace("\n", "\\n"))
+    def _render(self, data: List[List[str]], title: Union[str, None]) -> str:
+        title = title + "\n" if title else ""
+        return title + "\n".join(["\t".join(item).replace("\n", "\\n") for item in data])

--- a/src/binarylane/console/runners/action.py
+++ b/src/binarylane/console/runners/action.py
@@ -80,6 +80,7 @@ class ActionRunner(CommandRunner):
             status_code, received = response.status_code, response.parsed
 
         else:
-            logger.warning("Failed to get action")
+            if status_code < 400:
+                logger.warning("Failed to get action")
             super().response(status_code, received)
         return

--- a/src/binarylane/console/runners/command.py
+++ b/src/binarylane/console/runners/command.py
@@ -102,8 +102,11 @@ class CommandRunner(Runner):
         if status_code == 401:
             self.error('Unable to authenticate with API - please run "bl configure" to get started.')
         elif received:
+            if 400 <= status_code <= 599:
+                self._printer.error(received)
+                raise SystemExit(-1)
             self._printer.print(received)
-        elif status_code != 204:
+        elif not 200 <= status_code <= 299:
             self.error(f"HTTP {status_code}")
 
     def process(self, parsed: Any) -> None:

--- a/tests/integration/test_runner_error.py
+++ b/tests/integration/test_runner_error.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from _pytest.capture import CaptureFixture
+
+from binarylane.models.problem_details import ProblemDetails
+from binarylane.models.validation_problem_details import ValidationProblemDetails
+from tests.runner import TypeRunner
+
+from binarylane.console.commands.servers import post_v2_servers as create_server
+from binarylane.console.runners.command import CommandRunner
+
+
+def test_runner_validation_error(capsys: CaptureFixture[str]) -> None:
+    runner = TypeRunner[CommandRunner](create_server.Command)
+
+    runner.setMockResponse(400, ValidationProblemDetails(title="Validation Error", status=400, errors=None))
+
+    # should retun non zero exit code
+    with pytest.raises(SystemExit):
+        runner.run(["--image", "test", "--region", "test", "--size", "test"])
+
+    # and print to std err
+    captured = capsys.readouterr()
+    assert "Error: Validation" in captured.err
+
+    # leaving std out empty
+    assert "" == captured.out
+
+
+def test_runner_server_error(capsys: CaptureFixture[str]) -> None:
+    runner = TypeRunner[CommandRunner](create_server.Command)
+
+    runner.setMockResponse(500, ProblemDetails(title="Server Error", status=500))
+
+    # should retun non zero exit code
+    with pytest.raises(SystemExit):
+        runner.run(["--image", "test", "--region", "test", "--size", "test"])
+
+    # and print to std err
+    captured = capsys.readouterr()
+    assert "Error: Server Error" in captured.err
+
+    # leaving std out empty
+    assert "" == captured.out
+
+
+def test_runner_server_error_json(capsys: CaptureFixture[str]) -> None:
+    runner = TypeRunner[CommandRunner](create_server.Command)
+
+    runner.setMockResponse(500, ProblemDetails(title="Server Error", status=500))
+
+    # should retun non zero exit code
+    with pytest.raises(SystemExit):
+        runner.run(["--image", "test", "--region", "test", "--size", "test", "--output", "json"])
+
+    # and print to std err as raw json
+    captured = capsys.readouterr()
+    std_err = captured.err
+    res = json.loads(std_err)
+    assert res["title"] == "Server Error"
+    assert res["status"] == 500
+
+    # leaving std out empty
+    assert "" == captured.out

--- a/tests/printers/test_formatter.py
+++ b/tests/printers/test_formatter.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
+
+from binarylane.models.problem_details import ProblemDetails
+from binarylane.models.validation_problem_details import ValidationProblemDetails
+from binarylane.models.validation_problem_details_errors import ValidationProblemDetailsErrors
 
 from binarylane.console.printers import formatter
 
@@ -52,4 +56,51 @@ def test_format_primary_str() -> None:
     assert formatter.format_response(response, True) == {
         "table": [[formatter.DEFAULT_HEADING], [response.message]],
         "title": None,
+    }
+
+
+def test_format_problem_details() -> None:
+    response = ProblemDetails(
+        title="General Protection Fault",
+        type="https://httpstatuses.com/500",
+        status=500,
+        detail="The server encountered an unexpected condition that prevented it from fulfilling the request.",
+    )
+    assert formatter.format_response(response, True) == {
+        "table": cast(List[List[str]], []),
+        "title": f"Error: {response.title}\n\n{response.detail}",
+    }
+
+
+def test_format_validation_problem_details() -> None:
+    response = ValidationProblemDetails(
+        title="There were validation errors",
+        type="https://httpstatuses.com/400",
+        status=400,
+        detail="Please fix the errors and try again",
+        errors=ValidationProblemDetailsErrors.from_dict(
+            {"name": ["Name is required", "name must be unique"], "region": ["Region is required"]}
+        ),
+    )
+    assert formatter.format_response(response, True) == {
+        "table": [
+            ["field", "errors"],
+            ["name", "Name is required\nname must be unique"],
+            ["region", "Region is required"],
+        ],
+        "title": f"Error: {response.title}",
+    }
+
+
+def test_format_validation_problem_details_no_errors() -> None:
+    response = ValidationProblemDetails(
+        title="Email already in use",
+        type="https://httpstatuses.com/400",
+        status=400,
+        detail="Please fix the errors and try again",
+        errors=None,
+    )
+    assert formatter.format_response(response, True) == {
+        "table": cast(List[List[str]], []),
+        "title": f"Error: {response.title}",
     }

--- a/tests/printers/test_formatter.py
+++ b/tests/printers/test_formatter.py
@@ -6,8 +6,8 @@ from binarylane.console.printers import formatter
 
 
 def test_format_str() -> None:
-    assert formatter.format_response("test", True) == [[formatter.DEFAULT_HEADING], ["test"]]
-    assert formatter.format_response("test", False) == [["test"]]
+    assert formatter.format_response("test", True) == {"table": [[formatter.DEFAULT_HEADING], ["test"]], "title": None}
+    assert formatter.format_response("test", False) == {"table": [["test"]], "title": None}
 
 
 def test_format_list() -> None:
@@ -15,8 +15,8 @@ def test_format_list() -> None:
     ns2 = "ns2.binarylane.com.au"
     dns = [ns1, ns2]
 
-    assert formatter.format_response(dns, True) == [[formatter.DEFAULT_HEADING], [ns1], [ns2]]
-    assert formatter.format_response(dns, False) == [[ns1], [ns2]]
+    assert formatter.format_response(dns, True) == {"table": [[formatter.DEFAULT_HEADING], [ns1], [ns2]], "title": None}
+    assert formatter.format_response(dns, False) == {"table": [[ns1], [ns2]], "title": None}
 
 
 def test_format_primary_list() -> None:
@@ -29,11 +29,14 @@ def test_format_primary_list() -> None:
             self.dns = ["ns1.binarylane.com.au", "ns2.binarylane.com.au"]
 
     response = DnsList()
-    assert formatter.format_response(response, True) == [
-        [formatter.DEFAULT_HEADING],
-        [response.dns[0]],
-        [response.dns[1]],
-    ]
+    assert formatter.format_response(response, True) == {
+        "table": [
+            [formatter.DEFAULT_HEADING],
+            [response.dns[0]],
+            [response.dns[1]],
+        ],
+        "title": None,
+    }
 
 
 def test_format_primary_str() -> None:
@@ -46,4 +49,7 @@ def test_format_primary_str() -> None:
             self.message = "DNS Error"
 
     response = DnsError()
-    assert formatter.format_response(response, True) == [[formatter.DEFAULT_HEADING], [response.message]]
+    assert formatter.format_response(response, True) == {
+        "table": [[formatter.DEFAULT_HEADING], [response.message]],
+        "title": None,
+    }

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
-from typing import Generic, List, Type, TypeVar
+from types import MethodType
+from typing import Any, Generic, List, Tuple, Type, TypedDict, TypeVar, Union
 
 from binarylane.console.config import Config
 from binarylane.console.runners import Runner
+from binarylane.console.runners.command import CommandRunner
 
-T = TypeVar("T", bound=Runner)
+T = TypeVar("T", bound=CommandRunner)
+
+
+class MockResponse(TypedDict):
+    status_code: int
+    received: Any
 
 
 class TypeRunner(Runner, Generic[T]):
@@ -20,9 +27,24 @@ class TypeRunner(Runner, Generic[T]):
 
     _test: T
 
+    _mock_response: Union[MockResponse, None]
+
     def __init__(self, runner_type: Type[T]) -> None:
         super().__init__(None)
         self._test = runner_type(self)
+
+        # allow for mock responses
+        self._mock_response = None
+        old_request = self._test.request
+        harness = self
+
+        def sample_method(self: CommandRunner, client: Any, request: Any) -> Tuple[int, Any]:
+            if harness._mock_response:
+                return harness._mock_response["status_code"], harness._mock_response["received"]
+            else:
+                return old_request(client, request)
+
+        self._test.request = MethodType(sample_method, self._test)  # type: ignore
 
     @property
     def test(self) -> T:
@@ -35,6 +57,12 @@ class TypeRunner(Runner, Generic[T]):
     @property
     def description(self) -> str:
         return "test"
+
+    def setMockResponse(self, status_code: int, received: Any) -> None:
+        self._mock_response = MockResponse(status_code=status_code, received=received)
+
+    def clearMockResponse(self) -> None:
+        self._mock_response = None
 
     def run(self, args: List[str]) -> None:
         assert self._test is not None


### PR DESCRIPTION
When a request receives a response with 4xx or 5xx status codes, it is now treated as an error and `bl` will return error level of -1.
This MR also applies custom formatting to the ProblemDetails and ValidationProblemDetails objects that are common in the error response.

ProblemDetails (usually with 5xx errors) is just rendered as `ERROR: {title} - {detail}` where detail is optional

eg for a 404

```
PS C:\dev\vps\python-blcli> poetry run bl server action resize 33
ERROR:  Server not found.
```

ValidationProblemDetails (4xx validation errors) is similar to problem details, but includes the `errors` property as a table

```
PS C:\dev\python-blcli> bl server create --size blah --region blah2  --image blkah
Error: One or more validation errors occurred.
┌────────┬─────────────────────────────┐
│ field  │ errors                      │
├────────┼─────────────────────────────┤
│ size   │ size not found.             │
│ image  │ Operating system not found. │
│ region │ Facility not found.         │
└────────┴─────────────────────────────┘
```