### PR TITLE
feat: use OpenAPI x-cli-format as default value for --format option

### DIFF
--- a/src/binarylane/console/commands/actions/get_v2_actions.py
+++ b/src/binarylane/console/commands/actions/get_v2_actions.py
@@ -23,9 +23,12 @@ class Command(ListRunner):
     def default_format(self) -> List[str]:
         return [
             "id",
-            "status",
             "type",
             "started_at",
+            "completed_at",
+            "resource_id",
+            "status",
+            "result_data",
         ]
 
     @property

--- a/src/binarylane/console/commands/domains/get_v2_domains_domain_name_records.py
+++ b/src/binarylane/console/commands/domains/get_v2_domains_domain_name_records.py
@@ -31,9 +31,9 @@ class Command(ListRunner):
     def default_format(self) -> List[str]:
         return [
             "id",
-            "type",
             "name",
-            "ttl",
+            "type",
+            "data",
         ]
 
     @property

--- a/src/binarylane/console/commands/images/get_v2_images.py
+++ b/src/binarylane/console/commands/images/get_v2_images.py
@@ -27,12 +27,9 @@ class Command(ListRunner):
     def default_format(self) -> List[str]:
         return [
             "id",
+            "slug",
+            "distribution",
             "name",
-            "type",
-            "public",
-            "min_disk_size",
-            "size_gigabytes",
-            "status",
         ]
 
     @property

--- a/src/binarylane/console/commands/keys/get_v2_account_keys.py
+++ b/src/binarylane/console/commands/keys/get_v2_account_keys.py
@@ -23,9 +23,9 @@ class Command(ListRunner):
     def default_format(self) -> List[str]:
         return [
             "id",
-            "fingerprint",
-            "public_key",
+            "name",
             "default",
+            "fingerprint",
         ]
 
     @property

--- a/src/binarylane/console/commands/load_balancers/get_v2_load_balancers.py
+++ b/src/binarylane/console/commands/load_balancers/get_v2_load_balancers.py
@@ -24,9 +24,8 @@ class Command(ListRunner):
         return [
             "id",
             "name",
+            "region",
             "ip",
-            "status",
-            "created_at",
         ]
 
     @property

--- a/src/binarylane/console/commands/regions/get_v2_regions.py
+++ b/src/binarylane/console/commands/regions/get_v2_regions.py
@@ -24,7 +24,6 @@ class Command(ListRunner):
         return [
             "slug",
             "name",
-            "available",
         ]
 
     @property

--- a/src/binarylane/console/commands/server_actions/get_v2_servers_server_id_actions.py
+++ b/src/binarylane/console/commands/server_actions/get_v2_servers_server_id_actions.py
@@ -27,9 +27,12 @@ class Command(ListRunner):
     def default_format(self) -> List[str]:
         return [
             "id",
-            "status",
             "type",
             "started_at",
+            "completed_at",
+            "resource_id",
+            "status",
+            "result_data",
         ]
 
     @property

--- a/src/binarylane/console/commands/servers/get_v2_servers.py
+++ b/src/binarylane/console/commands/servers/get_v2_servers.py
@@ -25,13 +25,12 @@ class Command(ListRunner):
         return [
             "id",
             "name",
-            "memory",
+            "image",
             "vcpus",
+            "memory",
             "disk",
-            "created_at",
-            "status",
-            "size_slug",
-            "password_change_supported",
+            "region",
+            "networks",
         ]
 
     @property

--- a/src/binarylane/console/commands/servers/get_v2_servers_server_id_advanced_firewall_rules.py
+++ b/src/binarylane/console/commands/servers/get_v2_servers_server_id_advanced_firewall_rules.py
@@ -25,8 +25,12 @@ class Command(ListRunner):
     @property
     def default_format(self) -> List[str]:
         return [
+            "source_addresses",
+            "destination_addresses",
             "protocol",
+            "destination_ports",
             "action",
+            "description",
         ]
 
     @property

--- a/src/binarylane/console/commands/servers/get_v2_servers_server_id_backups.py
+++ b/src/binarylane/console/commands/servers/get_v2_servers_server_id_backups.py
@@ -27,12 +27,9 @@ class Command(ListRunner):
     def default_format(self) -> List[str]:
         return [
             "id",
+            "slug",
+            "distribution",
             "name",
-            "type",
-            "public",
-            "min_disk_size",
-            "size_gigabytes",
-            "status",
         ]
 
     @property

--- a/src/binarylane/console/commands/servers/get_v2_servers_server_id_kernels.py
+++ b/src/binarylane/console/commands/servers/get_v2_servers_server_id_kernels.py
@@ -27,6 +27,8 @@ class Command(ListRunner):
     def default_format(self) -> List[str]:
         return [
             "id",
+            "name",
+            "version",
         ]
 
     @property

--- a/src/binarylane/console/commands/servers/get_v2_servers_server_id_snapshots.py
+++ b/src/binarylane/console/commands/servers/get_v2_servers_server_id_snapshots.py
@@ -27,12 +27,9 @@ class Command(ListRunner):
     def default_format(self) -> List[str]:
         return [
             "id",
+            "slug",
+            "distribution",
             "name",
-            "type",
-            "public",
-            "min_disk_size",
-            "size_gigabytes",
-            "status",
         ]
 
     @property

--- a/src/binarylane/console/commands/sizes/get_v2_sizes.py
+++ b/src/binarylane/console/commands/sizes/get_v2_sizes.py
@@ -26,15 +26,13 @@ class Command(ListRunner):
     def default_format(self) -> List[str]:
         return [
             "slug",
-            "available",
-            "price_monthly",
-            "price_hourly",
-            "disk",
-            "memory",
-            "transfer",
-            "excess_transfer_cost_per_gigabyte",
+            "size_type",
             "vcpus",
             "vcpu_units",
+            "memory",
+            "disk",
+            "transfer",
+            "price_monthly",
         ]
 
     @property

--- a/templates/endpoint_module.py.jinja
+++ b/templates/endpoint_module.py.jinja
@@ -115,9 +115,19 @@ class Command({{ response_class['name'] }}):
 
     @property
     def default_format(self) -> List[str]:
+        {% set format = [] %}
+        {% for name, prop in list_response.data.properties.items() if prop['x-cli-format'] %}
+        {% set _ = format.append("%04d/%s" % (prop['x-cli-format'], name)) %}
+        {% endfor %}
+        {# if response object does not specify which properties to use, display required primitives #}
+        {% if not format %}
+        {% for prop in list_response.required_properties if prop.is_base_type %}
+        {% set _ = format.append("%04d/%s" % (loop.index, prop.name)) %}
+        {% endfor %}
+        {% endif %}
         return [
-            {% for prop in list_response.required_properties if prop.is_base_type %}
-            '{{ prop.name }}',
+            {% for entry in format|sort %}
+            '{{ entry.split('/')[1] }}',
             {% endfor %}
         ]
 

--- a/templates/endpoint_module.py.jinja
+++ b/templates/endpoint_module.py.jinja
@@ -125,6 +125,9 @@ class Command({{ response_class['name'] }}):
         {% set _ = format.append("%04d/%s" % (loop.index, prop.name)) %}
         {% endfor %}
         {% endif %}
+        {% if not format %}
+        {% include "default_format is empty" %}
+        {% endif %}
         return [
             {% for entry in format|sort %}
             '{{ entry.split('/')[1] }}',


### PR DESCRIPTION
`x-cli-format` is an optional integer added to individual top-level attributes of a response object schema.

When one or more top-level attributes of the response object have `x-cli-format` , the names of all such attributes are sorted by the extension's integer value and combined to form the default value of `--format`.