### PR TITLE
refactor: introduce shared Context to replace parent in Runner.__init__()

### DIFF
--- a/src/binarylane/console/__init__.py
+++ b/src/binarylane/console/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+
+class Context:
+    _prog: str
+
+    def __init__(self) -> None:
+        self._prog = "bl"
+
+    @property
+    def prog(self) -> str:
+        return self._prog
+
+    @prog.setter
+    def prog(self, name: str) -> None:
+        self._prog = f"bl {name}"

--- a/src/binarylane/console/app/__init__.py
+++ b/src/binarylane/console/app/__init__.py
@@ -3,10 +3,23 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from typing import List
 
-from binarylane.console.app.app import App
+from binarylane.console.app.app import AppRunner
+from binarylane.console.runners import Context
 
 logger = logging.getLogger(__name__)
+
+
+class App:
+    context: Context
+
+    def __init__(self) -> None:
+        self.context = Context()
+        self.runner = AppRunner(self.context)
+
+    def run(self, args: List[str]) -> None:
+        self.runner.run(args)
 
 
 def main() -> int:

--- a/src/binarylane/console/app/__init__.py
+++ b/src/binarylane/console/app/__init__.py
@@ -5,8 +5,8 @@ import os
 import sys
 from typing import List
 
+from binarylane.console import Context
 from binarylane.console.app.app import AppRunner
-from binarylane.console.runners import Context
 
 logger = logging.getLogger(__name__)
 

--- a/src/binarylane/console/app/app.py
+++ b/src/binarylane/console/app/app.py
@@ -39,8 +39,8 @@ class AppRunner(PackageRunner):
     @cached_property
     def app_runners(self) -> List[Runner]:
         return [
-            LazyLoader(self._parent, ".app.configure", "configure", "Configure access to BinaryLane API"),
-            LazyLoader(self._parent, ".app.version", "version", "Show the current version"),
+            LazyLoader(self._context, ".app.configure", "configure", "Configure access to BinaryLane API"),
+            LazyLoader(self._context, ".app.version", "version", "Show the current version"),
         ]
 
     def run(self, args: List[str]) -> None:

--- a/src/binarylane/console/app/app.py
+++ b/src/binarylane/console/app/app.py
@@ -39,8 +39,8 @@ class AppRunner(PackageRunner):
     @cached_property
     def app_runners(self) -> List[Runner]:
         return [
-            LazyLoader(self._context, ".app.configure", "configure", "Configure access to BinaryLane API"),
-            LazyLoader(self._context, ".app.version", "version", "Show the current version"),
+            LazyLoader(self.context, ".app.configure", "configure", "Configure access to BinaryLane API"),
+            LazyLoader(self.context, ".app.version", "version", "Show the current version"),
         ]
 
     def run(self, args: List[str]) -> None:

--- a/src/binarylane/console/app/app.py
+++ b/src/binarylane/console/app/app.py
@@ -9,7 +9,7 @@ from binarylane.console.runners.package import PackageRunner
 
 
 # FIXME: Combination of PackageRunner._prefix and App's overrides is difficult to support correctly
-class App(PackageRunner):
+class AppRunner(PackageRunner):
     """
     AppRunner is the 'root' runner for the application. In normal usage, all command line arguments are passed
     directly to run(). Apart from global flags, the primary function of this class is to invoke the
@@ -39,8 +39,8 @@ class App(PackageRunner):
     @cached_property
     def app_runners(self) -> List[Runner]:
         return [
-            LazyLoader(self, ".app.configure", "configure", "Configure access to BinaryLane API"),
-            LazyLoader(self, ".app.version", "version", "Show the current version"),
+            LazyLoader(self._parent, ".app.configure", "configure", "Configure access to BinaryLane API"),
+            LazyLoader(self._parent, ".app.version", "version", "Show the current version"),
         ]
 
     def run(self, args: List[str]) -> None:

--- a/src/binarylane/console/app/lazy_loader.py
+++ b/src/binarylane/console/app/lazy_loader.py
@@ -4,7 +4,8 @@ import importlib
 import logging
 from typing import List, Type
 
-from binarylane.console.runners import Runner
+from binarylane.console.app.lazy_runner import LazyRunner
+from binarylane.console.runners import Context, Runner
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +13,7 @@ logger = logging.getLogger(__name__)
 class LazyLoader(Runner):
     """ProxyRunner lazy imports a command from specified module."""
 
-    def __init__(self, parent: Runner, module_path: str, name: str, description: str) -> None:
+    def __init__(self, parent: Context, module_path: str, name: str, description: str) -> None:
         super().__init__(parent)
 
         self._module_path = module_path
@@ -36,7 +37,7 @@ class LazyLoader(Runner):
         return self._description
 
     @property
-    def runner_type(self) -> Type[Runner]:
+    def runner_type(self) -> Type[LazyRunner]:
         """Runner that will be executed by run()"""
         return importlib.import_module(f".{self.module_path}", package=__package__).Command
 

--- a/src/binarylane/console/app/lazy_loader.py
+++ b/src/binarylane/console/app/lazy_loader.py
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 class LazyLoader(Runner):
     """ProxyRunner lazy imports a command from specified module."""
 
-    def __init__(self, parent: Context, module_path: str, name: str, description: str) -> None:
-        super().__init__(parent)
+    def __init__(self, context: Context, module_path: str, name: str, description: str) -> None:
+        super().__init__(context)
 
         self._module_path = module_path
         self._name = name
@@ -22,7 +22,7 @@ class LazyLoader(Runner):
 
     @property
     def prog(self) -> str:
-        return self._parent.prog if self._parent else ""
+        return self._context.prog if self._context else ""
 
     @property
     def module_path(self) -> str:

--- a/src/binarylane/console/app/lazy_loader.py
+++ b/src/binarylane/console/app/lazy_loader.py
@@ -22,10 +22,6 @@ class LazyLoader(Runner):
         self._description = description
 
     @property
-    def prog(self) -> str:
-        return self._context.prog if self._context else ""
-
-    @property
     def module_path(self) -> str:
         return self._module_path
 

--- a/src/binarylane/console/app/lazy_loader.py
+++ b/src/binarylane/console/app/lazy_loader.py
@@ -4,8 +4,9 @@ import importlib
 import logging
 from typing import List, Type
 
+from binarylane.console import Context
 from binarylane.console.app.lazy_runner import LazyRunner
-from binarylane.console.runners import Context, Runner
+from binarylane.console.runners import Runner
 
 logger = logging.getLogger(__name__)
 

--- a/src/binarylane/console/app/lazy_runner.py
+++ b/src/binarylane/console/app/lazy_runner.py
@@ -9,7 +9,7 @@ class LazyRunner(Runner):
     proxy: Runner
 
     def __init__(self, parent: Runner) -> None:
-        super().__init__(parent)
+        super().__init__(parent._parent)
         self.proxy = parent
 
     @property

--- a/src/binarylane/console/app/lazy_runner.py
+++ b/src/binarylane/console/app/lazy_runner.py
@@ -6,16 +6,17 @@ from binarylane.console.runners import Runner
 class LazyRunner(Runner):
     """LazyRunner is a Runner that is imported ondemand by LazyLoader"""
 
-    proxy: Runner
+    # The loader provides our name and description
+    loader: Runner
 
-    def __init__(self, context: Runner) -> None:
-        super().__init__(context._context)
-        self.proxy = context
+    def __init__(self, loader: Runner) -> None:
+        super().__init__(loader._context)
+        self.loader = loader
 
     @property
     def name(self) -> str:
-        return self.proxy.name
+        return self.loader.name
 
     @property
     def description(self) -> str:
-        return self.proxy.description
+        return self.loader.description

--- a/src/binarylane/console/app/lazy_runner.py
+++ b/src/binarylane/console/app/lazy_runner.py
@@ -8,9 +8,9 @@ class LazyRunner(Runner):
 
     proxy: Runner
 
-    def __init__(self, parent: Runner) -> None:
-        super().__init__(parent._parent)
-        self.proxy = parent
+    def __init__(self, context: Runner) -> None:
+        super().__init__(context._context)
+        self.proxy = context
 
     @property
     def name(self) -> str:

--- a/src/binarylane/console/app/lazy_runner.py
+++ b/src/binarylane/console/app/lazy_runner.py
@@ -10,7 +10,7 @@ class LazyRunner(Runner):
     loader: Runner
 
     def __init__(self, loader: Runner) -> None:
-        super().__init__(loader._context)
+        super().__init__(loader.context)
         self.loader = loader
 
     @property

--- a/src/binarylane/console/app/version.py
+++ b/src/binarylane/console/app/version.py
@@ -14,7 +14,7 @@ class VersionRunner(LazyRunner):
         package = __package__
         version = self._distribution_version("binarylane-cli") or self._module_version(package) or "dev"
 
-        print(self.prog, version)
+        print(self._parent.prog, "version", version)
 
     def _distribution_version(self, package: str) -> Optional[str]:
         try:

--- a/src/binarylane/console/app/version.py
+++ b/src/binarylane/console/app/version.py
@@ -14,7 +14,7 @@ class VersionRunner(LazyRunner):
         package = __package__
         version = self._distribution_version("binarylane-cli") or self._module_version(package) or "dev"
 
-        print(self._parent.prog, "version", version)
+        print(self._context.prog, "version", version)
 
     def _distribution_version(self, package: str) -> Optional[str]:
         try:

--- a/src/binarylane/console/app/version.py
+++ b/src/binarylane/console/app/version.py
@@ -14,7 +14,7 @@ class VersionRunner(LazyRunner):
         package = __package__
         version = self._distribution_version("binarylane-cli") or self._module_version(package) or "dev"
 
-        print(self._context.prog, "version", version)
+        print(self.context.prog, "version", version)
 
     def _distribution_version(self, package: str) -> Optional[str]:
         try:

--- a/src/binarylane/console/runners/__init__.py
+++ b/src/binarylane/console/runners/__init__.py
@@ -12,13 +12,13 @@ from binarylane.console import Context
 class Runner(ABC):
     """Abstract base class for all Runner implementations"""
 
-    _context: Context
+    context: Context
 
     HELP = "--help"
     CHECK = "--blcli-check"
 
     def __init__(self, context: Context) -> None:
-        self._context = context
+        self.context = context
 
     @property
     @abstractmethod

--- a/src/binarylane/console/runners/__init__.py
+++ b/src/binarylane/console/runners/__init__.py
@@ -25,11 +25,13 @@ class Context:
 class Runner(ABC):
     """Abstract base class for all Runner implementations"""
 
+    _context: Context
+
     HELP = "--help"
     CHECK = "--blcli-check"
 
-    def __init__(self, parent: Context) -> None:
-        self._parent = parent
+    def __init__(self, context: Context) -> None:
+        self._context = context
 
     @property
     @abstractmethod

--- a/src/binarylane/console/runners/__init__.py
+++ b/src/binarylane/console/runners/__init__.py
@@ -6,20 +6,7 @@ import sys
 from abc import ABC, abstractmethod
 from typing import List
 
-
-class Context:
-    _names: List[str]
-
-    def __init__(self) -> None:
-        self._names = ["bl"]
-
-    @property
-    def prog(self) -> str:
-        """The 'program' name is used in help output to identify this runner"""
-        return " ".join(self._names)
-
-    def append(self, name: str) -> None:
-        self._names.append(name)
+from binarylane.console import Context
 
 
 class Runner(ABC):

--- a/src/binarylane/console/runners/__init__.py
+++ b/src/binarylane/console/runners/__init__.py
@@ -4,7 +4,22 @@ from __future__ import annotations
 import re
 import sys
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List
+
+
+class Context:
+    _names: List[str]
+
+    def __init__(self) -> None:
+        self._names = ["bl"]
+
+    @property
+    def prog(self) -> str:
+        """The 'program' name is used in help output to identify this runner"""
+        return " ".join(self._names)
+
+    def append(self, name: str) -> None:
+        self._names.append(name)
 
 
 class Runner(ABC):
@@ -12,15 +27,9 @@ class Runner(ABC):
 
     HELP = "--help"
     CHECK = "--blcli-check"
-    _parent: Optional[Runner]
 
-    def __init__(self, parent: Optional[Runner] = None) -> None:
+    def __init__(self, parent: Context) -> None:
         self._parent = parent
-
-    @property
-    def prog(self) -> str:
-        """The 'program' name is used in help output to identify this runner"""
-        return (self._parent.prog + " " if self._parent else "") + self.name
 
     @property
     @abstractmethod
@@ -39,9 +48,6 @@ class Runner(ABC):
     @abstractmethod
     def run(self, args: List[str]) -> None:
         """Subclasses implement their primary behaviour here"""
-
-    def __call__(self, args: List[str]) -> None:
-        self.run(args)
 
     @staticmethod
     def error(message: str) -> None:

--- a/src/binarylane/console/runners/command.py
+++ b/src/binarylane/console/runners/command.py
@@ -21,7 +21,6 @@ class CommandRunner(Runner):
     """CommandRunner parses input, executes API operation and displays the result"""
 
     _parser: Parser
-    _parent: Context
     _config: Config
     _client: AuthenticatedClient
 
@@ -29,10 +28,10 @@ class CommandRunner(Runner):
     _output: Optional[str]
     _header: Optional[bool]
 
-    def __init__(self, parent: Context) -> None:
-        super().__init__(parent)
+    def __init__(self, context: Context) -> None:
+        super().__init__(context)
         self._config = Config.load()
-        prog = f"{self._parent.prog} {self.name}"
+        prog = f"{self._context.prog} {self.name}"
         self._parser = Parser(prog=prog, description=self.description, epilog=self._epilog)
         self.configure(self._parser)
 

--- a/src/binarylane/console/runners/command.py
+++ b/src/binarylane/console/runners/command.py
@@ -11,7 +11,7 @@ from binarylane.console.config import Config
 from binarylane.console.parser import Mapping
 from binarylane.console.parser.parser import Parser
 from binarylane.console.printers import Printer, PrinterType, create_printer
-from binarylane.console.runners import Runner
+from binarylane.console.runners import Context, Runner
 from binarylane.console.runners.httpx_wrapper import CurlCommand
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ class CommandRunner(Runner):
     """CommandRunner parses input, executes API operation and displays the result"""
 
     _parser: Parser
-    _parent: Runner
+    _parent: Context
     _config: Config
     _client: AuthenticatedClient
 
@@ -29,10 +29,11 @@ class CommandRunner(Runner):
     _output: Optional[str]
     _header: Optional[bool]
 
-    def __init__(self, parent: Runner) -> None:
+    def __init__(self, parent: Context) -> None:
         super().__init__(parent)
         self._config = Config.load()
-        self._parser = Parser(prog=self.prog, description=self.description, epilog=self._epilog)
+        prog = f"{self._parent.prog} {self.name}"
+        self._parser = Parser(prog=prog, description=self.description, epilog=self._epilog)
         self.configure(self._parser)
 
         self._parser.add_argument(

--- a/src/binarylane/console/runners/command.py
+++ b/src/binarylane/console/runners/command.py
@@ -7,11 +7,12 @@ from typing import Any, List, Optional, Tuple
 
 from binarylane.client import AuthenticatedClient, Client
 
+from binarylane.console import Context
 from binarylane.console.config import Config
 from binarylane.console.parser import Mapping
 from binarylane.console.parser.parser import Parser
 from binarylane.console.printers import Printer, PrinterType, create_printer
-from binarylane.console.runners import Context, Runner
+from binarylane.console.runners import Runner
 from binarylane.console.runners.httpx_wrapper import CurlCommand
 
 logger = logging.getLogger(__name__)

--- a/src/binarylane/console/runners/command.py
+++ b/src/binarylane/console/runners/command.py
@@ -32,7 +32,7 @@ class CommandRunner(Runner):
     def __init__(self, context: Context) -> None:
         super().__init__(context)
         self._config = Config.load()
-        prog = f"{self._context.prog} {self.name}"
+        prog = f"{self.context.prog} {self.name}"
         self._parser = Parser(prog=prog, description=self.description, epilog=self._epilog)
         self.configure(self._parser)
 

--- a/src/binarylane/console/runners/module.py
+++ b/src/binarylane/console/runners/module.py
@@ -28,7 +28,7 @@ class ModuleRunner(Runner):
 
     @property
     def command_runner(self) -> CommandRunner:
-        return self.command_runner_type(self._context)
+        return self.command_runner_type(self.context)
 
     def run(self, args: List[str]) -> None:
         logger.debug("ModuleRunner for %s (%s). Received arguments: %s", self.name, self.module_path, args)

--- a/src/binarylane/console/runners/module.py
+++ b/src/binarylane/console/runners/module.py
@@ -17,10 +17,6 @@ class ModuleRunner(Runner):
     """ModuleRunner imports a runner from specified module."""
 
     @property
-    def prog(self) -> str:
-        return self._context.prog if self._context else ""
-
-    @property
     @abstractmethod
     def module_path(self) -> str:
         """Path of python module containing runner to import during run()"""

--- a/src/binarylane/console/runners/module.py
+++ b/src/binarylane/console/runners/module.py
@@ -32,7 +32,7 @@ class ModuleRunner(Runner):
 
     @property
     def command_runner(self) -> CommandRunner:
-        return self.command_runner_type(self)
+        return self.command_runner_type(self._parent)
 
     def run(self, args: List[str]) -> None:
         logger.debug("ModuleRunner for %s (%s). Received arguments: %s", self.name, self.module_path, args)

--- a/src/binarylane/console/runners/module.py
+++ b/src/binarylane/console/runners/module.py
@@ -18,7 +18,7 @@ class ModuleRunner(Runner):
 
     @property
     def prog(self) -> str:
-        return self._parent.prog if self._parent else ""
+        return self._context.prog if self._context else ""
 
     @property
     @abstractmethod
@@ -32,7 +32,7 @@ class ModuleRunner(Runner):
 
     @property
     def command_runner(self) -> CommandRunner:
-        return self.command_runner_type(self._parent)
+        return self.command_runner_type(self._context)
 
     def run(self, args: List[str]) -> None:
         logger.debug("ModuleRunner for %s (%s). Received arguments: %s", self.name, self.module_path, args)

--- a/src/binarylane/console/runners/package.py
+++ b/src/binarylane/console/runners/package.py
@@ -7,7 +7,8 @@ from argparse import ArgumentParser, HelpFormatter
 from typing import List, NoReturn, Sequence
 from binarylane.pycompat.functools import cached_property
 
-from binarylane.console.runners import Context, Runner
+from binarylane.console import Context
+from binarylane.console.runners import Runner
 from binarylane.console.runners.module import ModuleRunner
 
 logger = logging.getLogger(__name__)
@@ -120,7 +121,7 @@ class PackageRunner(Runner):
 
     def run(self, args: List[str]) -> None:
         if self._prefix:
-            self._context.append(self._prefix.split(" ")[-1])
+            self._context.prog = self._prefix
 
         self.parser = PackageParser(
             prog=f"{self.prog}",

--- a/src/binarylane/console/runners/package.py
+++ b/src/binarylane/console/runners/package.py
@@ -45,10 +45,6 @@ class PackageRunner(Runner):
         self._runners = []
 
     @property
-    def prog(self) -> str:
-        return self._context.prog
-
-    @property
     def name(self) -> str:
         return self.package_name if not self._prefix else self._prefix
 
@@ -124,9 +120,9 @@ class PackageRunner(Runner):
             self._context.prog = self._prefix
 
         self.parser = PackageParser(
-            prog=f"{self.prog}",
+            prog=f"{self._context.prog}",
             description=self.format_description(),
-            usage=f"{self.prog} [OPTIONS] COMMAND",
+            usage=f"{self._context.prog} [OPTIONS] COMMAND",
             add_help=False,
             formatter_class=PackageHelpFormatter,
             allow_abbrev=False,

--- a/src/binarylane/console/runners/package.py
+++ b/src/binarylane/console/runners/package.py
@@ -66,7 +66,7 @@ class PackageRunner(Runner):
     def module_runners(self) -> List[ModuleRunner]:
         """Runners to provide access to from this package"""
         commands = importlib.import_module(f".{self.package_path}", package=__package__).commands
-        return [cls(self._context) for cls in commands]
+        return [cls(self.context) for cls in commands]
 
     @property
     def runners(self) -> Sequence[Runner]:
@@ -104,7 +104,7 @@ class PackageRunner(Runner):
         # Add prefix runners for subcommands:
         for prefix in self._get_branches():
             branch_name = f"{self._prefix} {prefix}" if self._prefix else prefix
-            self._runners.append(self.__class__(self._context, branch_name))
+            self._runners.append(self.__class__(self.context, branch_name))
 
         self._runners.sort(key=self._get_command)
 
@@ -117,12 +117,12 @@ class PackageRunner(Runner):
 
     def run(self, args: List[str]) -> None:
         if self._prefix:
-            self._context.prog = self._prefix
+            self.context.prog = self._prefix
 
         self.parser = PackageParser(
-            prog=f"{self._context.prog}",
+            prog=f"{self.context.prog}",
             description=self.format_description(),
-            usage=f"{self._context.prog} [OPTIONS] COMMAND",
+            usage=f"{self.context.prog} [OPTIONS] COMMAND",
             add_help=False,
             formatter_class=PackageHelpFormatter,
             allow_abbrev=False,

--- a/src/binarylane/console/runners/package.py
+++ b/src/binarylane/console/runners/package.py
@@ -38,14 +38,14 @@ class PackageRunner(Runner):
     _prefix: str
     _runners: List[Runner]
 
-    def __init__(self, parent: Context, prefix: str = "") -> None:
-        super().__init__(parent)
+    def __init__(self, context: Context, prefix: str = "") -> None:
+        super().__init__(context)
         self._prefix = prefix
         self._runners = []
 
     @property
     def prog(self) -> str:
-        return self._parent.prog
+        return self._context.prog
 
     @property
     def name(self) -> str:
@@ -69,7 +69,7 @@ class PackageRunner(Runner):
     def module_runners(self) -> List[ModuleRunner]:
         """Runners to provide access to from this package"""
         commands = importlib.import_module(f".{self.package_path}", package=__package__).commands
-        return [cls(self._parent) for cls in commands]
+        return [cls(self._context) for cls in commands]
 
     @property
     def runners(self) -> Sequence[Runner]:
@@ -107,7 +107,7 @@ class PackageRunner(Runner):
         # Add prefix runners for subcommands:
         for prefix in self._get_branches():
             branch_name = f"{self._prefix} {prefix}" if self._prefix else prefix
-            self._runners.append(self.__class__(self._parent, branch_name))
+            self._runners.append(self.__class__(self._context, branch_name))
 
         self._runners.sort(key=self._get_command)
 
@@ -120,7 +120,7 @@ class PackageRunner(Runner):
 
     def run(self, args: List[str]) -> None:
         if self._prefix:
-            self._parent.append(self._prefix.split(" ")[-1])
+            self._context.append(self._prefix.split(" ")[-1])
 
         self.parser = PackageParser(
             prog=f"{self.prog}",

--- a/tests/integration/test_command_parsers.py
+++ b/tests/integration/test_command_parsers.py
@@ -8,13 +8,14 @@ from tests.runner import TypeRunner
 
 from binarylane.console.commands import commands
 from binarylane.console.parser import Attribute
+from binarylane.console.runners import Context
 from binarylane.console.runners.command import CommandRunner
 
 
 def get_all_command_runners() -> List[Type[CommandRunner]]:
     types = []
     for command_type in commands:
-        types.append(command_type().command_runner_type)
+        types.append(command_type(Context()).command_runner_type)
     return types
 
 

--- a/tests/integration/test_command_parsers.py
+++ b/tests/integration/test_command_parsers.py
@@ -6,9 +6,9 @@ import pytest
 
 from tests.runner import TypeRunner
 
+from binarylane.console import Context
 from binarylane.console.commands import commands
 from binarylane.console.parser import Attribute
-from binarylane.console.runners import Context
 from binarylane.console.runners.command import CommandRunner
 
 

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import pytest
 from _pytest.capture import CaptureFixture
 
-from tests.runner import TypeRunner
-
 from binarylane.console.app import App
-from binarylane.console.runners import Runner
 
 
 def test_package_command_metavar(capsys: CaptureFixture[str]) -> None:

--- a/tests/integration/test_response_types.py
+++ b/tests/integration/test_response_types.py
@@ -6,12 +6,13 @@ import pytest
 
 from binarylane.console.commands import commands
 from binarylane.console.printers import formatter
+from binarylane.console.runners import Context
 
 
 def ok_response_types() -> List[Any]:
     types = []
     for command_type in commands:
-        types.append(command_type().command_runner.ok_response_type)
+        types.append(command_type(Context()).command_runner.ok_response_type)
     return types
 
 

--- a/tests/integration/test_response_types.py
+++ b/tests/integration/test_response_types.py
@@ -4,9 +4,9 @@ from typing import Any, List
 
 import pytest
 
+from binarylane.console import Context
 from binarylane.console.commands import commands
 from binarylane.console.printers import formatter
-from binarylane.console.runners import Context
 
 
 def ok_response_types() -> List[Any]:

--- a/tests/integration/test_version.py
+++ b/tests/integration/test_version.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from _pytest.capture import CaptureFixture
+
+from binarylane.console.app import App
+
+
+def test_version(capsys: CaptureFixture[str]) -> None:
+    runner = App()
+    runner.run(["version"])
+
+    captured = capsys.readouterr()
+    assert "bl version" in captured.out

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Generic, List, Type, TypeVar
 
+from binarylane.console import Context
 from binarylane.console.config import Config
-from binarylane.console.runners import Context, Runner
+from binarylane.console.runners import Runner
 
 T = TypeVar("T", bound=Runner)
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Generic, List, Type, TypeVar
 
 from binarylane.console.config import Config
-from binarylane.console.runners import Runner
+from binarylane.console.runners import Context, Runner
 
 T = TypeVar("T", bound=Runner)
 
@@ -21,8 +21,8 @@ class TypeRunner(Runner, Generic[T]):
     _test: T
 
     def __init__(self, runner_type: Type[T]) -> None:
-        super().__init__(None)
-        self._test = runner_type(self)
+        super().__init__(Context())
+        self._test = runner_type(self._parent)
 
     @property
     def test(self) -> T:

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -23,7 +23,7 @@ class TypeRunner(Runner, Generic[T]):
 
     def __init__(self, runner_type: Type[T]) -> None:
         super().__init__(Context())
-        self._test = runner_type(self._context)
+        self._test = runner_type(self.context)
 
     @property
     def test(self) -> T:

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -22,7 +22,7 @@ class TypeRunner(Runner, Generic[T]):
 
     def __init__(self, runner_type: Type[T]) -> None:
         super().__init__(Context())
-        self._test = runner_type(self._parent)
+        self._test = runner_type(self._context)
 
     @property
     def test(self) -> T:


### PR DESCRIPTION
- Introduce new Context class, which replaces parent Runner as mandatory __init__ argument
- At runtime, a single instance of Context will be provided to all runners.
- Move Runner.prog to Context 
- Rename App to AppRunner, and add new App that creates the Context and initialises AppRunner

In future, Context will be used to provide shared access to "program state" - configuration settings, available commands, etc.

