### PR TITLE
refactor: make scripts/generate.py perform required fixups for openapi-python-client lazy imports

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -9,7 +9,7 @@ import urllib.error
 import urllib.request
 from argparse import SUPPRESS, ArgumentParser
 from pathlib import Path
-from typing import List, Sequence
+from typing import List, Optional, Sequence
 
 
 def mkempty(directory: Path) -> None:
@@ -70,8 +70,7 @@ def library_eager_imports() -> None:
     """
 
     import_pattern = re.compile("^\\s+from .* import (.*)")
-    forwardref_pattern = re.compile("^(\\s+[a-z0-9_]+: )['\"]([A-Za-z0-9]+)['\"](\\s*)$")
-    docstring_pattern = re.compile(r'^\s*(' + r'"""[^"]*(?!""")|' + r"'''[^'](?!''')" + r')')  #start/end but not both
+    docstring_pattern = re.compile(r"^\s*(" + r'"""[^"]*(?!""")|' + r"'''[^'](?!''')" + r")")  # start/end but not both
     for module in Path.cwd().rglob("*.py"):
 
         # Read module source code lines into a list
@@ -84,7 +83,7 @@ def library_eager_imports() -> None:
         docstring_block = False
         forwardref_types: List[str] = []
         for line_number, line in enumerate(lines):
-            new_value = line[:-1]
+            new_value: Optional[str] = line[:-1]
             indented_import = import_pattern.match(line)
             if docstring_pattern.match(line):
                 docstring_block = not docstring_block
@@ -153,7 +152,7 @@ def library_eager_imports() -> None:
             file.writelines(lines)
 
 
-def library_absolufy_imports():
+def library_absolufy_imports() -> None:
     """
     Convert relative imports within openapi-python-client generated library to absolute.
 

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -72,7 +72,6 @@ def library_eager_imports() -> None:
     import_pattern = re.compile("^\\s+from .* import (.*)")
     docstring_pattern = re.compile(r"^\s*(" + r'"""[^"]*(?!""")|' + r"'''[^'](?!''')" + r")")  # start/end but not both
     for module in Path.cwd().rglob("*.py"):
-
         # Read module source code lines into a list
         with open(module, "rt") as file:
             lines = file.readlines()
@@ -115,13 +114,11 @@ def library_eager_imports() -> None:
 
             # If we are changing this line, we are in a docstring and this line is an attribute: description
             if new_value and pre_forwardref_fixup != new_value and docstring_block and re.search(": .", line):
-
                 # Grab the next line and remove newline
                 next_line = lines[line_number + 1][:-1]
 
                 # If next line isnt end of the docstring block, and looks like a wrapped description
                 if not docstring_pattern.match(next_line) and re.match(r"^\s+[a-zA-Z]([^:]+)$", next_line):
-
                     # Remove and store the whitespace indentation from next_line for use later
                     indentation = ""
                     while next_line[0] == " ":


### PR DESCRIPTION
This PR will enable removal of the `enable_lazy_imports` changes from our `openapi-python-client` fork, by providing the required alterations to generated code  in `scripts/generate.py`.

In v0.12.0 upstream `openapi-python-client` changed the generated code to use ForwardRef type annotations in various parts of the generated code. This was a problem for us because our `formatter` module needs to resolve those types at runtime as it walks the response object, so the solution we used at the time was to add a new `enable_lazy_imports` class attribute to `Property` and use its value to determine whether to change the behaviour of the `Property` hierarchy back to  normal ('eager') imports.

While it would be possible to feed the relevant types to `typing.get_type_hints()` via its `localns` parameter;  since we do not know ahead of time which particular types are required we would have to import all types from `models`, which is a pretty significant performance hit for CLI usage.

By performing the relevant fixups in `generate.py`, we avoid that while bringing us a step closer to switching back to the upstream `openapi-python-client`.