### PR TITLE
fix: output action properties at completion of command runner

### DIFF
--- a/src/binarylane/console/printers/__init__.py
+++ b/src/binarylane/console/printers/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from enum import Enum
 
 from binarylane.console.printers.json_printer import JsonPrinter
+from binarylane.console.printers.none_printer import NonePrinter
 from binarylane.console.printers.plain_printer import PlainPrinter
 from binarylane.console.printers.printer import Printer
 from binarylane.console.printers.table_printer import TablePrinter
@@ -23,6 +24,7 @@ class PrinterType(Enum):
     TABLE = TablePrinter
     TSV = TsvPrinter
     JSON = JsonPrinter
+    NONE = NonePrinter
 
 
 def create_printer(name: str) -> Printer:

--- a/src/binarylane/console/printers/none_printer.py
+++ b/src/binarylane/console/printers/none_printer.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from binarylane.console.printers.printer import Printer
+
+
+class NonePrinter(Printer):
+    def print(self, response: Any, fields: Optional[List[str]] = None) -> None:
+        pass

--- a/src/binarylane/console/runners/action.py
+++ b/src/binarylane/console/runners/action.py
@@ -72,14 +72,15 @@ class ActionRunner(CommandRunner):
             status = f"{received.action.type}: {step} ({received.action.progress.percent_complete}%) ... "
             self._progress(status)
 
-            # If action has completed, provide final status and return to caller
+            # Check if action has completed
             if received.action.completed_at:
                 self._progress(f"{received.action.status}.\n")
-                return
+                break
 
+            # Wait and then refresh action response
             time.sleep(5)
             response = sync_detailed(received.action.id, client=self._client)
             status_code, received = response.status_code, response.parsed
 
-        # Action did not complete so something went wrong - use standard error handling routine:
+        # Action has now completed (or errored), process final response
         super().response(status_code, received)

--- a/src/binarylane/console/runners/action.py
+++ b/src/binarylane/console/runners/action.py
@@ -21,6 +21,10 @@ class ActionRunner(CommandRunner):
     _async: bool = False
     _quiet: bool = False
 
+    @property
+    def _default_output(self) -> str:
+        return "none"
+
     def configure(self, parser: Parser) -> None:
         super().configure(parser)
 
@@ -71,7 +75,7 @@ class ActionRunner(CommandRunner):
 
             # Check if action has completed
             if received.action.completed_at:
-                self._progress(f"{received.action.status}.\n")
+                self._progress(f"{received.action.type}: {received.action.result_data or received.action.status}\n")
                 break
 
             # Wait and then refresh action response

--- a/src/binarylane/console/runners/actionlink.py
+++ b/src/binarylane/console/runners/actionlink.py
@@ -8,6 +8,10 @@ from binarylane.console.runners.action import ActionRunner
 class ActionLinkRunner(ActionRunner):
     """ActionLinkRunner handles command responses with an optional action ID attached"""
 
+    @property
+    def _default_output(self) -> str:
+        return "table"
+
     def response(self, status_code: int, received: Any) -> None:
         from binarylane.models.actions_links import ActionsLinks
 

--- a/src/binarylane/console/runners/actionlink.py
+++ b/src/binarylane/console/runners/actionlink.py
@@ -19,7 +19,7 @@ class ActionLinkRunner(ActionRunner):
         # Show action progress on stdout
         if not self._async:
             action_id = links.actions[0].id
-            super().response(status_code, action_id)
+            self.wait_for_action(status_code, action_id)
 
         # Print the 'other' object (e.g. server) from the response
         self._printer.print(received)

--- a/src/binarylane/console/runners/command.py
+++ b/src/binarylane/console/runners/command.py
@@ -8,7 +8,7 @@ from binarylane.models.problem_details import ProblemDetails
 from binarylane.models.validation_problem_details import ValidationProblemDetails
 
 from binarylane.console.printers import Printer, PrinterType, create_printer
-from binarylane.console.runners import ExitCode, Runner
+from binarylane.console.runners import Context, ExitCode, Runner
 from binarylane.console.runners.httpx_wrapper import CurlCommand
 from binarylane.console.util import create_client
 
@@ -32,8 +32,16 @@ class CommandRunner(Runner):
     _client: AuthenticatedClient
 
     _print_curl: Optional[bool]
-    _output: str = _DEFAULT_OUTPUT
+    _output: str
     _header: bool = _DEFAULT_HEADER
+
+    def __init__(self, context: Context) -> None:
+        super().__init__(context)
+        self._output = self._default_output
+
+    @property
+    def _default_output(self) -> str:
+        return _DEFAULT_OUTPUT
 
     @abstractmethod
     def create_mapping(self) -> Mapping:
@@ -57,7 +65,7 @@ class CommandRunner(Runner):
         parser.add_argument(
             "--output",
             dest="runner_output",
-            default=_DEFAULT_OUTPUT,
+            default=self._default_output,
             metavar="OUTPUT",
             choices=printers,
             help='Desired output format [%(choices)s] (default: "%(default)s")',


### PR DESCRIPTION
Currently ActionRunner when used without --async does not produce any output, making it impossible to see result of `bl server action uptime` command.

This PR changes behaviour of ActionRunner so that:
- it prints the action's result_data (if any) as part of the final progress message on stderr
- any of `--output table/plain/tsv/json` can be used to print the completed action to stdout