### PR TITLE
feat: add x-cli-lookup attribute to load-balancer and vpc

### DIFF
--- a/src/binarylane/console/commands/api/delete_v2_load_balancers_load_balancer_id.py
+++ b/src/binarylane/console/commands/api/delete_v2_load_balancers_load_balancer_id.py
@@ -9,6 +9,7 @@ from binarylane.models.problem_details import ProblemDetails
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_load_balancers as api_get_v2_load_balancers
 from binarylane.console.parser import Mapping, PrimitiveAttribute
 from binarylane.console.runners.command import CommandRunner
 
@@ -28,13 +29,18 @@ class Command(CommandRunner):
     def create_mapping(self) -> Mapping:
         mapping = Mapping(CommandRequest)
 
+        def lookup_load_balancer_id(ref: str) -> Union[None, int]:
+            return api_get_v2_load_balancers.Command(self._context).lookup(ref)
+
         mapping.add(
             PrimitiveAttribute(
                 "load_balancer_id",
                 int,
                 required=True,
                 option_name=None,
-                description="""The ID of the load balancer to cancel.""",
+                metavar="load_balancer",
+                description="""The ID or name of the load balancer to cancel.""",
+                lookup=lookup_load_balancer_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/delete_v2_load_balancers_load_balancer_id_forwarding_rules.py
+++ b/src/binarylane/console/commands/api/delete_v2_load_balancers_load_balancer_id_forwarding_rules.py
@@ -13,6 +13,7 @@ from binarylane.models.validation_problem_details import ValidationProblemDetail
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_load_balancers as api_get_v2_load_balancers
 from binarylane.console.parser import ListAttribute, Mapping, PrimitiveAttribute
 from binarylane.console.runners.command import CommandRunner
 
@@ -34,13 +35,18 @@ class Command(CommandRunner):
     def create_mapping(self) -> Mapping:
         mapping = Mapping(CommandRequest)
 
+        def lookup_load_balancer_id(ref: str) -> Union[None, int]:
+            return api_get_v2_load_balancers.Command(self._context).lookup(ref)
+
         mapping.add(
             PrimitiveAttribute(
                 "load_balancer_id",
                 int,
                 required=True,
                 option_name=None,
-                description="""The ID of the load balancer for which forwarding rules should be removed.""",
+                metavar="load_balancer",
+                description="""The ID or name of the load balancer for which forwarding rules should be removed.""",
+                lookup=lookup_load_balancer_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/delete_v2_load_balancers_load_balancer_id_servers.py
+++ b/src/binarylane/console/commands/api/delete_v2_load_balancers_load_balancer_id_servers.py
@@ -11,6 +11,7 @@ from binarylane.models.validation_problem_details import ValidationProblemDetail
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_load_balancers as api_get_v2_load_balancers
 import binarylane.console.commands.api.get_v2_servers as api_get_v2_servers
 from binarylane.console.parser import Mapping, PrimitiveAttribute
 from binarylane.console.runners.command import CommandRunner
@@ -33,13 +34,18 @@ class Command(CommandRunner):
     def create_mapping(self) -> Mapping:
         mapping = Mapping(CommandRequest)
 
+        def lookup_load_balancer_id(ref: str) -> Union[None, int]:
+            return api_get_v2_load_balancers.Command(self._context).lookup(ref)
+
         mapping.add(
             PrimitiveAttribute(
                 "load_balancer_id",
                 int,
                 required=True,
                 option_name=None,
-                description="""The ID of the load balancer for which servers should be removed.""",
+                metavar="load_balancer",
+                description="""The ID or name of the load balancer for which servers should be removed.""",
+                lookup=lookup_load_balancer_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/delete_v2_vpcs_vpc_id.py
+++ b/src/binarylane/console/commands/api/delete_v2_vpcs_vpc_id.py
@@ -9,6 +9,7 @@ from binarylane.models.problem_details import ProblemDetails
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_vpcs as api_get_v2_vpcs
 from binarylane.console.parser import Mapping, PrimitiveAttribute
 from binarylane.console.runners.command import CommandRunner
 
@@ -28,13 +29,18 @@ class Command(CommandRunner):
     def create_mapping(self) -> Mapping:
         mapping = Mapping(CommandRequest)
 
+        def lookup_vpc_id(ref: str) -> Union[None, int]:
+            return api_get_v2_vpcs.Command(self._context).lookup(ref)
+
         mapping.add(
             PrimitiveAttribute(
                 "vpc_id",
                 int,
                 required=True,
                 option_name=None,
-                description="""The target vpc id.""",
+                metavar="vpc",
+                description="""The target vpc id or name.""",
+                lookup=lookup_vpc_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/get_v2_load_balancers.py
+++ b/src/binarylane/console/commands/api/get_v2_load_balancers.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from binarylane.api.load_balancers.get_v2_load_balancers import sync_detailed
+from binarylane.console.util import create_client
 from binarylane.models.links import Links
 from binarylane.models.load_balancers_response import LoadBalancersResponse
 
@@ -54,6 +55,18 @@ class Command(ListRunner):
             "server_ids": """The server IDs of the servers that are currently in the load balancer pool (regardless of their current 'health').""",
             "region": """The region the load balancer is located in. If this value is null the load balancer is an 'AnyCast' load balancer.""",
         }
+
+    def lookup(self, ref: str) -> Optional[int]:
+        status_code, received = self.request(create_client(self._context), CommandRequest())
+        if status_code != 200:
+            super().response(status_code, received)
+
+        assert isinstance(received, LoadBalancersResponse)
+        for item in received.load_balancers:
+            if item.name == ref:
+                return item.id
+        else:
+            return None
 
     @property
     def reference_url(self) -> str:

--- a/src/binarylane/console/commands/api/get_v2_load_balancers_load_balancer_id.py
+++ b/src/binarylane/console/commands/api/get_v2_load_balancers_load_balancer_id.py
@@ -10,6 +10,7 @@ from binarylane.models.problem_details import ProblemDetails
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_load_balancers as api_get_v2_load_balancers
 from binarylane.console.parser import Mapping, PrimitiveAttribute
 from binarylane.console.runners.command import CommandRunner
 
@@ -29,13 +30,18 @@ class Command(CommandRunner):
     def create_mapping(self) -> Mapping:
         mapping = Mapping(CommandRequest)
 
+        def lookup_load_balancer_id(ref: str) -> Union[None, int]:
+            return api_get_v2_load_balancers.Command(self._context).lookup(ref)
+
         mapping.add(
             PrimitiveAttribute(
                 "load_balancer_id",
                 int,
                 required=True,
                 option_name=None,
-                description="""The ID of the load balancer to fetch.""",
+                metavar="load_balancer",
+                description="""The ID or name of the load balancer to fetch.""",
+                lookup=lookup_load_balancer_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/get_v2_vpcs.py
+++ b/src/binarylane/console/commands/api/get_v2_vpcs.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from binarylane.api.vpcs.get_v2_vpcs import sync_detailed
+from binarylane.console.util import create_client
 from binarylane.models.links import Links
 from binarylane.models.vpcs_response import VpcsResponse
 
@@ -41,6 +42,18 @@ class Command(ListRunner):
             "ip_range": """The IPv4 range for this VPC in CIDR format.""",
             "route_entries": """The route entries that control how network traffic is directed through the VPC environment.""",
         }
+
+    def lookup(self, ref: str) -> Optional[int]:
+        status_code, received = self.request(create_client(self._context), CommandRequest())
+        if status_code != 200:
+            super().response(status_code, received)
+
+        assert isinstance(received, VpcsResponse)
+        for item in received.vpcs:
+            if item.name == ref:
+                return item.id
+        else:
+            return None
 
     @property
     def reference_url(self) -> str:

--- a/src/binarylane/console/commands/api/get_v2_vpcs_vpc_id.py
+++ b/src/binarylane/console/commands/api/get_v2_vpcs_vpc_id.py
@@ -10,6 +10,7 @@ from binarylane.models.vpc_response import VpcResponse
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_vpcs as api_get_v2_vpcs
 from binarylane.console.parser import Mapping, PrimitiveAttribute
 from binarylane.console.runners.command import CommandRunner
 
@@ -29,13 +30,18 @@ class Command(CommandRunner):
     def create_mapping(self) -> Mapping:
         mapping = Mapping(CommandRequest)
 
+        def lookup_vpc_id(ref: str) -> Union[None, int]:
+            return api_get_v2_vpcs.Command(self._context).lookup(ref)
+
         mapping.add(
             PrimitiveAttribute(
                 "vpc_id",
                 int,
                 required=True,
                 option_name=None,
-                description="""The target vpc id.""",
+                metavar="vpc",
+                description="""The target vpc id or name.""",
+                lookup=lookup_vpc_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/get_v2_vpcs_vpc_id_members.py
+++ b/src/binarylane/console/commands/api/get_v2_vpcs_vpc_id_members.py
@@ -13,6 +13,7 @@ from binarylane.types import UNSET, Unset
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_vpcs as api_get_v2_vpcs
 from binarylane.console.parser import Mapping, PrimitiveAttribute
 from binarylane.console.runners.list import ListRunner
 
@@ -66,13 +67,18 @@ class Command(ListRunner):
     def create_mapping(self) -> Mapping:
         mapping = Mapping(CommandRequest)
 
+        def lookup_vpc_id(ref: str) -> Union[None, int]:
+            return api_get_v2_vpcs.Command(self._context).lookup(ref)
+
         mapping.add(
             PrimitiveAttribute(
                 "vpc_id",
                 int,
                 required=True,
                 option_name=None,
-                description="""The target vpc id.""",
+                metavar="vpc",
+                description="""The target vpc id or name.""",
+                lookup=lookup_vpc_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/patch_v2_vpcs_vpc_id.py
+++ b/src/binarylane/console/commands/api/patch_v2_vpcs_vpc_id.py
@@ -14,6 +14,7 @@ from binarylane.types import Unset
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_vpcs as api_get_v2_vpcs
 from binarylane.console.parser import ListAttribute, Mapping, PrimitiveAttribute
 from binarylane.console.runners.command import CommandRunner
 
@@ -35,13 +36,18 @@ class Command(CommandRunner):
     def create_mapping(self) -> Mapping:
         mapping = Mapping(CommandRequest)
 
+        def lookup_vpc_id(ref: str) -> Union[None, int]:
+            return api_get_v2_vpcs.Command(self._context).lookup(ref)
+
         mapping.add(
             PrimitiveAttribute(
                 "vpc_id",
                 int,
                 required=True,
                 option_name=None,
-                description="""The target vpc id.""",
+                metavar="vpc",
+                description="""The target vpc id or name.""",
+                lookup=lookup_vpc_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/post_v2_load_balancers_load_balancer_id_forwarding_rules.py
+++ b/src/binarylane/console/commands/api/post_v2_load_balancers_load_balancer_id_forwarding_rules.py
@@ -13,6 +13,7 @@ from binarylane.models.validation_problem_details import ValidationProblemDetail
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_load_balancers as api_get_v2_load_balancers
 from binarylane.console.parser import ListAttribute, Mapping, PrimitiveAttribute
 from binarylane.console.runners.command import CommandRunner
 
@@ -34,13 +35,18 @@ class Command(CommandRunner):
     def create_mapping(self) -> Mapping:
         mapping = Mapping(CommandRequest)
 
+        def lookup_load_balancer_id(ref: str) -> Union[None, int]:
+            return api_get_v2_load_balancers.Command(self._context).lookup(ref)
+
         mapping.add(
             PrimitiveAttribute(
                 "load_balancer_id",
                 int,
                 required=True,
                 option_name=None,
-                description="""The ID of the load balancer to which forwarding rules should be added.""",
+                metavar="load_balancer",
+                description="""The ID or name of the load balancer to which forwarding rules should be added.""",
+                lookup=lookup_load_balancer_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/post_v2_load_balancers_load_balancer_id_servers.py
+++ b/src/binarylane/console/commands/api/post_v2_load_balancers_load_balancer_id_servers.py
@@ -11,6 +11,7 @@ from binarylane.models.validation_problem_details import ValidationProblemDetail
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_load_balancers as api_get_v2_load_balancers
 import binarylane.console.commands.api.get_v2_servers as api_get_v2_servers
 from binarylane.console.parser import Mapping, PrimitiveAttribute
 from binarylane.console.runners.command import CommandRunner
@@ -33,13 +34,18 @@ class Command(CommandRunner):
     def create_mapping(self) -> Mapping:
         mapping = Mapping(CommandRequest)
 
+        def lookup_load_balancer_id(ref: str) -> Union[None, int]:
+            return api_get_v2_load_balancers.Command(self._context).lookup(ref)
+
         mapping.add(
             PrimitiveAttribute(
                 "load_balancer_id",
                 int,
                 required=True,
                 option_name=None,
-                description="""The ID of the load balancer to which servers should be added.""",
+                metavar="load_balancer",
+                description="""The ID or name of the load balancer to which servers should be added.""",
+                lookup=lookup_load_balancer_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/post_v2_servers.py
+++ b/src/binarylane/console/commands/api/post_v2_servers.py
@@ -14,6 +14,7 @@ from binarylane.types import Unset
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_vpcs as api_get_v2_vpcs
 from binarylane.console.parser import ListAttribute, Mapping, ObjectAttribute, PrimitiveAttribute
 from binarylane.console.runners.actionlink import ActionLinkRunner
 
@@ -95,13 +96,18 @@ class Command(ActionLinkRunner):
             )
         )
 
+        def lookup_vpc_id(ref: str) -> Union[None, int]:
+            return api_get_v2_vpcs.Command(self._context).lookup(ref)
+
         json_body.add(
             PrimitiveAttribute(
                 "vpc_id",
                 Union[Unset, None, int],
                 required=False,
-                option_name="vpc-id",
+                option_name=("vpc", "vpc-id"),
+                metavar="vpc",
                 description="""Leave null to use default (public) network for the selected region.""",
+                lookup=lookup_vpc_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/post_v_2_servers_server_id_actions_change_network.py
+++ b/src/binarylane/console/commands/api/post_v_2_servers_server_id_actions_change_network.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from binarylane.client import Client
 
 import binarylane.console.commands.api.get_v2_servers as api_get_v2_servers
+import binarylane.console.commands.api.get_v2_vpcs as api_get_v2_vpcs
 from binarylane.console.parser import Mapping, PrimitiveAttribute
 from binarylane.console.runners.action import ActionRunner
 
@@ -62,13 +63,18 @@ class Command(ActionRunner):
             )
         )
 
+        def lookup_vpc_id(ref: str) -> Union[None, int]:
+            return api_get_v2_vpcs.Command(self._context).lookup(ref)
+
         json_body.add(
             PrimitiveAttribute(
                 "vpc_id",
                 Union[Unset, None, int],
                 required=False,
-                option_name="vpc-id",
+                option_name=("vpc", "vpc-id"),
+                metavar="vpc",
                 description="""If this is null the server will be moved into the default public network for the server's region.""",
+                lookup=lookup_vpc_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/put_v2_load_balancers_load_balancer_id.py
+++ b/src/binarylane/console/commands/api/put_v2_load_balancers_load_balancer_id.py
@@ -17,6 +17,7 @@ from binarylane.types import Unset
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_load_balancers as api_get_v2_load_balancers
 import binarylane.console.commands.api.get_v2_servers as api_get_v2_servers
 from binarylane.console.parser import ListAttribute, Mapping, ObjectAttribute, PrimitiveAttribute
 from binarylane.console.runners.command import CommandRunner
@@ -39,13 +40,18 @@ class Command(CommandRunner):
     def create_mapping(self) -> Mapping:
         mapping = Mapping(CommandRequest)
 
+        def lookup_load_balancer_id(ref: str) -> Union[None, int]:
+            return api_get_v2_load_balancers.Command(self._context).lookup(ref)
+
         mapping.add(
             PrimitiveAttribute(
                 "load_balancer_id",
                 int,
                 required=True,
                 option_name=None,
-                description="""The ID of the load balancer to update.""",
+                metavar="load_balancer",
+                description="""The ID or name of the load balancer to update.""",
+                lookup=lookup_load_balancer_id,
             )
         )
 

--- a/src/binarylane/console/commands/api/put_v2_vpcs_vpc_id.py
+++ b/src/binarylane/console/commands/api/put_v2_vpcs_vpc_id.py
@@ -14,6 +14,7 @@ from binarylane.types import Unset
 if TYPE_CHECKING:
     from binarylane.client import Client
 
+import binarylane.console.commands.api.get_v2_vpcs as api_get_v2_vpcs
 from binarylane.console.parser import ListAttribute, Mapping, PrimitiveAttribute
 from binarylane.console.runners.command import CommandRunner
 
@@ -35,13 +36,18 @@ class Command(CommandRunner):
     def create_mapping(self) -> Mapping:
         mapping = Mapping(CommandRequest)
 
+        def lookup_vpc_id(ref: str) -> Union[None, int]:
+            return api_get_v2_vpcs.Command(self._context).lookup(ref)
+
         mapping.add(
             PrimitiveAttribute(
                 "vpc_id",
                 int,
                 required=True,
                 option_name=None,
-                description="""The target vpc id.""",
+                metavar="vpc",
+                description="""The target vpc id or name.""",
+                lookup=lookup_vpc_id,
             )
         )
 

--- a/templates/lookups.jinja
+++ b/templates/lookups.jinja
@@ -8,13 +8,17 @@ available in OpenAPI Specification published by BinaryLane.
 
 {# Map of attribute name to command that can resolve attribute reference. #}
 {% set lookup_map = {
+    "load_balancer_id": "load-balancer list",
     "server_id": "server list",
+    "vpc_id": "vpc list",
 } %}
 
 {# Map of command to {id,ref} obect specifying the attributes within
 x-cli-command's response that provide the reference (input) and id (output). #}
 {% set entity_map = {
+    "load-balancer list": {"id": "id", "ref": "name"},
     "server list": {"id": "id", "ref": "name"},
+    "vpc list": {"id": "id", "ref": "name"},
 } %}
 
 {# Add x-cli-lookup to attributes that support lookup. #}


### PR DESCRIPTION
The following commands now support identifying a load-balancer by ID or name: 
- load-balancer get
- load-balancer update
- load-balancer delete
- load-balancer rule create
- load-balancer rule delete
- load-balancer server create
- load-balancer server delete

The following commands now support identifying a VPC by ID or name:
- server create
- server action change-network
- vpc get
- vpc members
- vpc patch 
- vpc update
- vpc delete 
